### PR TITLE
Increase memory from 1024 to 2048

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -23,11 +23,11 @@ Vagrant.configure(2) do |config|
         box.vm.box_version = ">= 0.0.6, < 1.0.0"
 
         box.vm.provider "vmware_fusion" do |v|
-            v.vmx["memsize"] = "1024"
+            v.vmx["memsize"] = "2048"
         end
 
         box.vm.provider "virtualbox" do |vb|
-            vb.customize ["modifyvm", :id, "--memory", "1024"]
+            vb.customize ["modifyvm", :id, "--memory", "2048"]
         end
 
         box.vm.hostname = "#{hostname}"


### PR DESCRIPTION
The default memory size of `1024` is not enough to run composer with a larger dependency tree.
