### PR TITLE
Adds solr role to ansible playbook

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
     config.vm.define "#{project}" do |box|
 
         box.vm.box = "palantir/drupalbox"
-        box.vm.box_version = ">= 0.0.6, < 1.0.0"
+        box.vm.box_version = ">= 0.1.1, < 1.0.0"
 
         box.vm.provider "vmware_fusion" do |v|
             v.vmx["memsize"] = "2048"

--- a/conf/vagrant/provisioning/drupal8-skeleton.yml
+++ b/conf/vagrant/provisioning/drupal8-skeleton.yml
@@ -3,10 +3,12 @@
   vars:
     timezone: America/Chicago
     mysql_root_pass: root
+    solr_enabled: false
     system_packages: ["php5-gd"]
   roles:
     - { role: common }
     - { role: php }
     - { role: vhost }
+    - { role: solr }
     - { role: drush }
     - { role: gulp }

--- a/conf/vagrant/provisioning/roles/solr/defaults/main.yml
+++ b/conf/vagrant/provisioning/roles/solr/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+solr_enabled: false

--- a/conf/vagrant/provisioning/roles/solr/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/solr/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Solr | Disable Jetty Service
+  become: yes
+  service:
+    name: jetty
+    state: started
+    enabled: yes
+  when: solr_enabled == True
+  tags: solr


### PR DESCRIPTION
Solr is disabled by default starting in drupalbox v0.1.0. This role allows you to enable the service via Ansible.
