### PR TITLE
Remove second Solr configuration 

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -13,7 +13,6 @@ hostname    = "#{project}.local"
 extra_hostnames = []
 
 ansible_solr_enabled = @ansible_solr_enabled@
-ansible_solr_enabled = false
 ansible_https_enabled = @ansible_https_enabled@
 ansible_project_web_root = "@ansible_project_web_root@"
 ansible_timezone = "America/Chicago"


### PR DESCRIPTION
This one always overwrites the one set with the wizard.

You can test by deleting `Vagrantfile` on a project created with Drupal Skeleton and running `vendor/bin/the-vagrant-installer` and accepting all defaults.