### PR TITLE
Change HTTPS default to yes

### DIFF
--- a/tasks/vagrant.xml
+++ b/tasks/vagrant.xml
@@ -8,7 +8,7 @@
     <basename property="default.projectname" file="${application.startdir}" suffix="local" />
     <property name="default.project_web_root" value="web" />
     <property name="default.enable_solr" value="Y" />
-    <property name="default.enable_https" value="n" />
+    <property name="default.enable_https" value="Y" />
     <property name="default.copy_roles" value="n" />
     <property name="default.custom_playbook" value="n" />
 


### PR DESCRIPTION
As https has gained almost universal support we should be spinning up boxes with it set so that developers encounter fewer mixed-content errors.