### PR TITLE
Generate better self-signed certs

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure(2) do |config|
         ansible.extra_vars = {
             "project" => project,
             "hostname" => hostname,
+            "extra_hostnames" => extra_hostnames,
             "solr_enabled" => ansible_solr_enabled,
             "https_enabled" => ansible_https_enabled,
             "project_web_root" => ansible_project_web_root,

--- a/conf/vagrant/provisioning/roles/https/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/https/tasks/main.yml
@@ -13,9 +13,15 @@
   when: https_enabled == True
   tags: https
 
+- name: Add config for self-signed certs
+  become: True
+  template: src=san.cnf dest=/etc/apache2/ssl/san.cnf
+  when: https_enabled == True
+  tags: https
+  
 - name: Generate self-signed certificate
   become: True
-  command: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/apache2/ssl/apache.key -out /etc/apache2/ssl/apache.crt -subj "/C=US/ST=Illinois/L=Evanston/O=Palantir.net, Inc./OU=DevOps/CN={{ hostname }}"
+  command: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/apache2/ssl/apache.key -out /etc/apache2/ssl/apache.crt -subj "/C=US/ST=Illinois/L=Evanston/O=Palantir.net, Inc./OU=DevOps/CN={{ hostname }}"  -config /etc/apache2/ssl/san.cnf
   when: https_enabled == True
   tags: https
 

--- a/conf/vagrant/provisioning/roles/https/templates/san.cnf
+++ b/conf/vagrant/provisioning/roles/https/templates/san.cnf
@@ -1,0 +1,17 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
+x509_extensions    = v3_req
+
+[req_distinguished_name]
+commonName       = {{ hostname }}
+organizationName = Palantir.net, Inc.
+localityName     = Evanston
+countryName      = US
+
+[v3_req]
+# The extentions to add to a self-signed cert
+subjectKeyIdentifier = hash
+basicConstraints     = critical,CA:false
+subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}
+keyUsage             = critical,digitalSignature,keyEncipherment

--- a/conf/vagrant/provisioning/roles/https/templates/san.cnf
+++ b/conf/vagrant/provisioning/roles/https/templates/san.cnf
@@ -13,5 +13,7 @@ countryName      = US
 # The extentions to add to a self-signed cert
 subjectKeyIdentifier = hash
 basicConstraints     = critical,CA:false
-subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}
+subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}{% for host in extra_hostnames  %}
+,DNS:{{ host }}
+{% endfor %}
 keyUsage             = critical,digitalSignature,keyEncipherment


### PR DESCRIPTION
As per https://security.stackexchange.com/a/166645.

To test:
- pull into a box with `ansible_https_enabled = true`
- `vagrant reload --provision`
- open your site in a browser
- observe the certificate has a SAN
<img width="467" alt="screenshot_7_9_18__5_56_pm" src="https://user-images.githubusercontent.com/238201/42480139-8e373686-83a1-11e8-95c5-13ba6c1835b1.png">
- follow these instructions https://deliciousbrains.com/https-locally-without-browser-privacy-errors/#installing-certificate to locally trust the certificate 
- refresh the page and observe GREEN!
<img width="210" alt="page_not_found___northcentral_technical_college" src="https://user-images.githubusercontent.com/238201/42480170-bbcb2670-83a1-11e8-9228-1ab71a7eddf7.png">
