### PR TITLE
Fix for running drush php-eval and drush sql-query commands within the vagrant

### DIFF
--- a/conf/vagrant/provisioning/roles/drush/bin/drush
+++ b/conf/vagrant/provisioning/roles/drush/bin/drush
@@ -25,4 +25,4 @@ elif [ $REPO ] && [ -e $REPO/drush/drushrc.php ]; then
   DRUSH_FLAGS="-c $REPO/drush/drushrc.php"
 fi
 
-$THE_DRUSH $DRUSH_FLAGS $@
+$THE_DRUSH $DRUSH_FLAGS "$@"


### PR DESCRIPTION
Fix bug where quoted commands (like those to drush sql-query and drush php-eval) would fail with error messages unrelated to the command.