### PR TITLE
Update triggers usage for Vagrant 2.1.0

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.require_version ">= 2.1.0"
 
-%w{ vagrant-hostmanager vagrant-auto_network vagrant-triggers }.each do |plugin|
+%w{ vagrant-hostmanager vagrant-auto_network }.each do |plugin|
     unless Vagrant.has_plugin?(plugin)
         raise "#{plugin} plugin is not installed. Please install with: vagrant plugin install #{plugin}"
     end
@@ -72,8 +72,11 @@ Vagrant.configure(2) do |config|
         end
     end
 
-    config.trigger.before [:up, :reload] do
-        run "composer install --ignore-platform-reqs"
+    config.trigger.before [:up, :reload] do |trigger|
+        trigger.name = "Composer Install"
+        trigger.run = {
+            inline: "composer install --ignore-platform-reqs"
+        }
     end
 
 end

--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 2.1.0"
+
 %w{ vagrant-hostmanager vagrant-auto_network vagrant-triggers }.each do |plugin|
     unless Vagrant.has_plugin?(plugin)
         raise "#{plugin} plugin is not installed. Please install with: vagrant plugin install #{plugin}"


### PR DESCRIPTION
* Requires using Vagrant >= 2.1.0
* Updates the default Vagrantfile to use the triggers functionality from Vagrant core instead of [vagrant-triggers](https://github.com/emyl/vagrant-triggers)

### To update Vagrant:

**warning: this means that you won't be able to use Vagrantfiles that require vagrant-triggers**

1. Uninstall the `vagrant-triggers` plugin with `vagrant plugin uninstall vagrant-triggers`
2. Update you Vagrant to >= 2.1.0, either by [downloading from vagrantup.com](https://www.vagrantup.com/downloads.html), or if you use homebrew cask, `brew cask reinstall vagrant`
3. Repair/reinstall your other Vagrant plugins with `vagrant plugin repair` (this is generally required after updating Vagrant)

### To update a project with the changes from this PR:

1. Get this code in the project (composer require whatever)
2. Reinstall the-vagrant: `vendor/bin/the-vagrant-installer`
3. Answer the prompts to regenerate your Vagrantfile
4. Examine the diff and make sure other customizations aren't removed from the file

This will *not* require destroying the vagrant box for your project.

### Concerns

The problem with this update is that any projects using it will require that developers have Vagrant >= 2.1.0, and many older projects will be requiring Vagrant *before* 2.1.0 -- so we'll probably need to update those other projects as close to in sync as possible with when developers update their Vagrant installs.

I've added info to the [wiki on updating to Vagrant >= 2.1.0](https://github.com/palantirnet/documentation/wiki/Virtual-Machines-and-Vagrant#updating-to-vagrant-210), but I'm still mulling over how to handle this team-wide update.