### PR TITLE
Remove breaking newline

### DIFF
--- a/conf/vagrant/provisioning/roles/https/templates/san.cnf
+++ b/conf/vagrant/provisioning/roles/https/templates/san.cnf
@@ -13,7 +13,6 @@ countryName      = US
 # The extentions to add to a self-signed cert
 subjectKeyIdentifier = hash
 basicConstraints     = critical,CA:false
-subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}{% for host in extra_hostnames  %}
-,DNS:{{ host }}{% endfor %}
+subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}{% for host in extra_hostnames  %},DNS:{{ host }}{% endfor %}
 
 keyUsage             = critical,digitalSignature,keyEncipherment


### PR DESCRIPTION
When running `vagrant provision` on a site with values in the `extra_hostnames` var, I received the following error:

```
TASK [https : Generate self-signed certificate] ********************************
fatal: [umus]: FAILED! => {"changed": true, "cmd": ["openssl", "req", "-x509", "-nodes", "-days", "365", "-newkey", "rsa:2048", "-keyout", "/etc/apache2/ssl/apache.key", "-out", "/etc/apache2/ssl/apache.crt", "-subj", "/C=US/ST=Illinois/L=Evanston/O=Palantir.net, Inc./OU=DevOps/CN=umus.local", "-config", "/etc/apache2/ssl/san.cnf"], "delta": "0:00:00.007738", "end": "2018-08-14 14:43:22.011689", "msg": "non-zero return code", "rc": 1, "start": "2018-08-14 14:43:22.003951", "stderr": "error on line 17 of /etc/apache2/ssl/san.cnf\n140351008384664:error:0E079065:configuration file routines:DEF_LOAD_BIO:missing equal sign:conf_def.c:345:line 17", "stderr_lines": ["error on line 17 of /etc/apache2/ssl/san.cnf", "140351008384664:error:0E079065:configuration file routines:DEF_LOAD_BIO:missing equal sign:conf_def.c:345:line 17"], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/Users/aschwab/Sites/umus/vendor/palantirnet/the-vagrant/conf/vagrant/provisioning/drupal8-skeleton.retry
```

The `san.cnf` generated had some newlines which made things unhappy.

```
[v3_req]
# The extentions to add to a self-signed cert
subjectKeyIdentifier = hash
basicConstraints     = critical,CA:false
subjectAltName       = DNS:umus.local,DNS:www.umus.local,DNS:healthblog.uofmhealth.local
,DNS:labblog.uofmhealth.local
,DNS:www.uofmhealth.local

keyUsage             = critical,digitalSignature,keyEncipherment
```

Applying this patch made things cleaner and happy:
```
[v3_req]
# The extentions to add to a self-signed cert
subjectKeyIdentifier = hash
basicConstraints     = critical,CA:false
subjectAltName       = DNS:umus.local,DNS:www.umus.local,DNS:healthblog.uofmhealth.local,DNS:labblog.uofmhealth.local,DNS:www.uofmhealth.local
keyUsage             = critical,digitalSignature,keyEncipherment
```