### PR TITLE
Add nvm and Node provisioning to the-vagrant

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -16,6 +16,7 @@ extra_hostnames = []
 
 ansible_solr_enabled = @ansible_solr_enabled@
 ansible_https_enabled = @ansible_https_enabled@
+ansible_node_version = @ansible_node_version@
 ansible_project_web_root = "@ansible_project_web_root@"
 ansible_timezone = "America/Chicago"
 ansible_system_packages = []
@@ -63,7 +64,13 @@ Vagrant.configure(2) do |config|
             "project_web_root" => ansible_project_web_root,
             "timezone" => ansible_timezone,
             "system_packages" => ansible_system_packages,
+            "nvm_version" => "v0.33.11",
+            "nvm_default_node_version" => ansible_node_version,
+            "nvm_node_versions" => [ ansible_node_version ],
         }
+
+        ansible.galaxy_role_file = "vendor/palantirnet/the-vagrant/conf/vagrant/provisioning/requirements.yml"
+        ansible.galaxy_roles_path = "vendor/palantirnet/the-vagrant/conf/vagrant/provisioning/roles/"
     end
 
     if (defined?(ansible_custom_playbook) && !ansible_custom_playbook.empty?)

--- a/conf/vagrant/provisioning/drupal8-skeleton.yml
+++ b/conf/vagrant/provisioning/drupal8-skeleton.yml
@@ -15,3 +15,7 @@
     - { role: solr }
     - { role: drush }
     - { role: gulp }
+    - { role: leanbit.nvm,
+        nvm_user: "vagrant",
+        become: true,
+      }

--- a/conf/vagrant/provisioning/requirements.yml
+++ b/conf/vagrant/provisioning/requirements.yml
@@ -1,0 +1,4 @@
+---
+
+- src: leanbit.nvm
+  version: 0.0.4

--- a/tasks/vagrant.xml
+++ b/tasks/vagrant.xml
@@ -9,6 +9,7 @@
     <property name="default.project_web_root" value="web" />
     <property name="default.enable_solr" value="Y" />
     <property name="default.enable_https" value="Y" />
+    <property name="default.node_version" value="8" />
     <property name="default.copy_roles" value="n" />
     <property name="default.custom_playbook" value="n" />
 
@@ -20,6 +21,7 @@
         <propertyprompt propertyName="project_web_root" defaultValue="${default.project_web_root}" promptText="Web root within your project" promptCharacter=":" useExistingValue="true"/>
         <input propertyName="enable_solr" message="Enable Solr " promptChar="?" validArgs="Y,n" defaultValue="${default.enable_solr}" />
         <input propertyName="enable_https" message="Enable HTTPS " promptChar="?" validArgs="Y,n" defaultValue="${default.enable_https}" />
+        <propertyprompt propertyName="node_version" defaultValue="${default.node_version}" promptText="Node version" promptCharacter=":" useExistingValue="true"/>
         <input propertyName="copy_roles" message="Copy Ansible roles into your project for customization " promptChar="?" validArgs="Y,n" defaultValue="${default.copy_roles}" />
 
         <if>
@@ -106,6 +108,7 @@
                     <token key="playbook" value="${vagrant.ansible.playbook}"/>
                     <token key="ansible_solr_enabled" value="${ansible_solr_enabled}"/>
                     <token key="ansible_https_enabled" value="${ansible_https_enabled}"/>
+                    <token key="ansible_node_version" value="${node_version}"/>
                     <token key="ansible_project_web_root" value="${project_web_root}"/>
                     <token key="ansible_custom_playbook" value="${ansible_custom_playbook}"/>
                 </replacetokens>


### PR DESCRIPTION
Completes [ZRAD-118](https://palantir.atlassian.net/browse/ZRAD-118) - Add nvm/node provisioning to the-vagrant.

### To test:

1. In an existing project with up-to-date the-vagrant (for example, [palantirnet-d8](https://github.com/palantirnet/palantirnet-d8/)), update to this branch: `composer require --dev palantirnet/the-vagrant:dev-nvm-node-provisioning`
2. Reinstall the-vagrant: `vendor/bin/the-vagrant-installer`
3. Make sure you use the same hostname when you respond
4. Check the diff to verify that changes to the Vagrantfile are limited to the changes in this PR: `git diff`
5. Re-provision your Vagrant box: `vagrant up --provision` or `vagrant reload --provision`
6. SSH in to the Vagrant environment
7. Verify that nvm is installed: `nvm --version` (should be `0.33.11`)
8. Verify that node is installed: `node --version` (should be whatever you entered when you installed)

### Open questions:

* Should the default version of node be 8, 9, or something else?