### PR TITLE
ZRAD-127: provision gitconfig into the vm

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -46,8 +46,6 @@ Vagrant.configure(2) do |config|
 
         box.ssh.forward_agent = true
     end
-    
-    config.vm.provision "file", source: "~/.gitconfig", destination: "$HOME/.gitconfig"
 
     config.vm.provision "the-vagrant", type: "ansible" do |ansible|
         ansible.playbook = "@playbook@"

--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -46,6 +46,8 @@ Vagrant.configure(2) do |config|
 
         box.ssh.forward_agent = true
     end
+    
+    config.vm.provision "file", source: "~/.gitconfig", destination: "$HOME/.gitconfig"
 
     config.vm.provision "the-vagrant", type: "ansible" do |ansible|
         ansible.playbook = "@playbook@"

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -13,7 +13,11 @@
 - name: Common | Configure PALANTIR_ENVIRONMENT variable
   lineinfile: dest=/home/vagrant/.profile state=present line='export PALANTIR_ENVIRONMENT="vagrant"'
   tags: common
-  
+
+- name: Common | Copy user's gitconfig from host
+  copy: src=~/.gitconfig dest=/home/vagrant/.gitconfig
+  tags: common
+
 - name: Common | Get user.name from host's gitconfig
   git_config:
     name: user.name

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -18,14 +18,14 @@
   git_config:
     name: user.name
     scope: global
-    register: git_author_name
+  register: git_author_name
   tags: common
 
 - name: Common | Get user.email from host's gitconfig
   git_config:
     name: user.email
     scope: global
-    register: git_author_email
+  register: git_author_email
   tags: common
   
 - name: Common | Copy gitconfig from template

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -40,7 +40,6 @@
 - name: Common | Configure global gitignore
   command: /usr/bin/git config --global core.excludesfile ~/.gitignore
   tags: common
-  
 
 - name: Check for user-specific provisioning script
   stat: path=/var/www/{{ hostname }}/conf/provision-user

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -13,6 +13,25 @@
 - name: Common | Configure PALANTIR_ENVIRONMENT variable
   lineinfile: dest=/home/vagrant/.profile state=present line='export PALANTIR_ENVIRONMENT="vagrant"'
   tags: common
+  
+- name: Common | Get user.name from host's gitconfig
+  git_config:
+    name: user.name
+    scope: global
+    register: git_author_name
+  tags: common
+
+- name: Common | Get user.email from host's gitconfig
+  git_config:
+    name: user.email
+    scope: global
+    register: git_author_email
+  tags: common
+  
+- name: Common | Copy gitconfig from template
+  template:
+    src: gitconfig
+    dest: /home/vagrant/.gitconfig
 
 - name: Common | Copy gitignore
   copy: src=roles/common/templates/gitignore dest=/home/vagrant/.gitignore
@@ -21,6 +40,7 @@
 - name: Common | Configure global gitignore
   command: /usr/bin/git config --global core.excludesfile ~/.gitignore
   tags: common
+  
 
 - name: Check for user-specific provisioning script
   stat: path=/var/www/{{ hostname }}/conf/provision-user

--- a/conf/vagrant/provisioning/roles/common/templates/gitconfig
+++ b/conf/vagrant/provisioning/roles/common/templates/gitconfig
@@ -1,4 +1,4 @@
 # This is Git's per-user configuration file.
 [user]
-	name = {{ git_author_name }}
-	email = {{ git_author_email }}
+	name = {{ git_author_name.config_value }}
+	email = {{ git_author_email.config_value }}

--- a/conf/vagrant/provisioning/roles/common/templates/gitconfig
+++ b/conf/vagrant/provisioning/roles/common/templates/gitconfig
@@ -1,0 +1,4 @@
+# This is Git's per-user configuration file.
+[user]
+	name = {{ git_author_name }}
+	email = {{ git_author_email }}


### PR DESCRIPTION
See ticket [ZRAD-127](https://palantir.atlassian.net/browse/ZRAD-127) and issue https://github.com/palantirnet/the-vagrant/issues/57.

Uses Vagrant's file provisioner to copy `.gitconfig` from the host.

Ansible will subsequently modify `excludesfile` to use the `.gitignore` that it copies into the VM.

To test:
- Install the-vagrant into a project using this branch.
- Run provisioning `vagrant reload --provision`
- `vagrant ssh` and verify that `~/.gitconfig` has the correct `user.name` and `user.email`

Questions:
Should this detect a missing `user.name` and `user.email` and prompt the developer to configure Git prior to provisioning the VM, or display a warning?