### PR TITLE
Fix san.conf template subjectAltName line

### DIFF
--- a/conf/vagrant/provisioning/roles/https/templates/san.cnf
+++ b/conf/vagrant/provisioning/roles/https/templates/san.cnf
@@ -13,7 +13,6 @@ countryName      = US
 # The extentions to add to a self-signed cert
 subjectKeyIdentifier = hash
 basicConstraints     = critical,CA:false
-subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}{% for host in extra_hostnames  %}
-,DNS:{{ host }}{% endfor %}
+subjectAltName       = DNS:{{ hostname }},DNS:www.{{ hostname }}{% for host in extra_hostnames  %},DNS:{{ host }}{% endfor %}
 
 keyUsage             = critical,digitalSignature,keyEncipherment


### PR DESCRIPTION
The following error is generated while generating a self-signed cert when provisioning a VM with HTTPS:

```
TASK [https : Generate self-signed certificate] ********************************
fatal: [mount-sinai-mv]: FAILED! => {"changed": true, "cmd": ["openssl", "req", "-x509", "-nodes", "-days", "365", "-newkey", "rsa:2048", "-keyout", "/etc/apache2/ssl/apache.key", "-out", "/etc/apache2/ssl/apache.crt", "-subj", "/C=US/ST=Illinois/L=Evanston/O=Palantir.net, Inc./OU=DevOps/CN=mount-sinai-mv.local", "-config", "/etc/apache2/ssl/san.cnf"], "delta": "0:00:00.009053", "end": "2018-10-29 15:06:18.942871", "msg": "non-zero return code", "rc": 1, "start": "2018-10-29 15:06:18.933818", "stderr": "error on line 17 of /etc/apache2/ssl/san.cnf\n139707715139224:error:0E079065:configuration file routines:DEF_LOAD_BIO:missing equal sign:conf_def.c:345:line 17", "stderr_lines": ["error on line 17 of /etc/apache2/ssl/san.cnf", "139707715139224:error:0E079065:configuration file routines:DEF_LOAD_BIO:missing equal sign:conf_def.c:345:line 17"], "stdout": "", "stdout_lines": []}
```

This should only be an issue for projects that use `extra_hostnames` with HTTPS.  This PR updates the template to remove the line-break in the `{% for %}` loop on the subjectAltName line in the `san.conf` template.