### PR TITLE
Disable audio on the VM

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
         box.vm.box_version = ">= 1.2.0, < 2.0"
 
         box.vm.provider "virtualbox" do |vb|
-            vb.customize ["modifyvm", :id, "--memory", "2048"]
+            vb.customize ["modifyvm", :id, "--memory", "2048", "--audio", "none"]
         end
 
         box.vm.hostname = "#{hostname}"


### PR DESCRIPTION
## Description

This adds flags to the call to `modifyvm` in the Vagrantfile to disable audio in the VM upon boot.  If audio is enabled for a running VM, high CPU utilization will occur after waking the host from sleep.

(See https://forums.virtualbox.org/viewtopic.php?f=8&t=90027)

## Testing instructions

- Halt all running VMs on the host, except one.
- Cause the host to sleep.
- Wait about a minute.
- Wake the host and notice high CPU utilization by the `VBoxHeadless` process in Activity Monitor.
- Add the changes in the PR to the Vagrant file of the running VM.
- `vagrant halt && vagrant up` ("reload" may not allow the audio to be disabled on the running VM; I haven't tested that)
- Cause the host to sleep.
- Wait about a minute.
- Wake the host and notice there is no longer high CPU utilization.
