### PR TITLE
Add role to install selenium, chrome, and chromedriver.

### DIFF
--- a/conf/vagrant/provisioning/roles/selenium-webdriver/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/selenium-webdriver/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Create directory for Selenium
+  become: yes
+  file:
+    path: /usr/local/share/selenium
+    state: directory
+
+- name: Selenium
+  become: yes
+  get_url:
+    url: https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
+    dest: /usr/local/share/selenium/selenium-server-standalone.jar
+
+- name: Create directory for Chromedriver
+  become: yes
+  file:
+    path: /usr/local/share/chromedriver
+    state: directory
+
+- name: Download Chromedriver
+  become: yes
+  unarchive:
+    remote_src: yes
+    src: https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip
+    dest: /usr/local/share/chromedriver
+    mode: "+x"
+
+- name: "Install Chrome - Ensure Google linux signing key present"
+  become: yes
+  apt_key:
+    url: https://dl-ssl.google.com/linux/linux_signing_key.pub
+
+- name: "Install Chrome - Ensure Google Chrome repo present"
+  become: yes
+  apt_repository:
+    repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    filename: "google-chrome"
+    state: present
+    update_cache: yes
+
+- name: Install Chrome
+  become: yes
+  apt:
+    name: google-chrome-stable


### PR DESCRIPTION
The `behat.yml` configuration I tested with looks something like,

```
default:
  suites:
    default:
      contexts:
        - FeatureContext
        - Drupal\DrupalExtension\Context\DrupalContext
        - Drupal\DrupalExtension\Context\MinkContext
        - Drupal\DrupalExtension\Context\MessageContext
        - Drupal\DrupalExtension\Context\DrushContext
      filters:
        tags: "~@skipci"
  gherkin:
    cache: ~
  extensions:
    Behat\MinkExtension:
      browser_name: 'chrome'
      selenium2:
        wd_host: "http://127.0.0.1:4444/wd/hub"
        capabilities: { "browserName": "chrome", "browser": "chrome", "version": "62", 'chrome': {'switches':['--no-sandbox', '--headless']}}
      javascript_session: selenium2
      base_url: [INSERT HERE]
    Drupal\DrupalExtension:
      blackbox: ~
      api_driver: 'drupal'
      drupal:
        drupal_root: 'web'
      text:
        username_field: 'name'
        password_field: 'pass'
        log_out: 'Log out'
      region_map:
        anywhere: "*"

circle:
  extensions:
    Behat\MinkExtension:
      base_url: [INSERT HERE]:8000
```

The critical part was,

```
    Behat\MinkExtension:
      browser_name: 'chrome'
      selenium2:
        wd_host: "http://127.0.0.1:4444/wd/hub"
        capabilities: { "browserName": "chrome", "browser": "chrome", "version": "62", 'chrome': {'switches':['--no-sandbox', '--headless']}}
      javascript_session: selenium2
      base_url: [INSERT HERE]
```

I also created a Phing script to start the selenium server. I couldn't get it to stay on when I tried to add it to the Ansible part. Maybe someone else has ideas for that.

```
    <target name="start-selenium">
        <exec command='java -jar -Dwebdriver.chrome.driver="/usr/local/share/chromedriver/chromedriver" /usr/local/share/selenium/selenium-server-standalone.jar >/dev/null 2>&amp;1 &amp;' dir="/home" />
    </target>
```