### PR TITLE
Refs #63: Adds drupal-check to the provisioning.

### DIFF
--- a/conf/vagrant/provisioning/drupal8-skeleton.yml
+++ b/conf/vagrant/provisioning/drupal8-skeleton.yml
@@ -14,6 +14,7 @@
     - { role: https }
     - { role: solr }
     - { role: drush }
+    - { role: drupal-check }
     - { role: gulp }
     - { role: leanbit.nvm,
         nvm_user: "vagrant",

--- a/conf/vagrant/provisioning/roles/drupal-check/tasks/mail.yml
+++ b/conf/vagrant/provisioning/roles/drupal-check/tasks/mail.yml
@@ -1,9 +1,0 @@
----
-
-- name: Drupal Check | Download drupal check
-  command: curl -O -L https://github.com/mglaman/drupal-check/releases/latest/download/drupal-check.phar
-  tags: drupal-check
-
-- name: Druupal Check | Copy Drupal Check
-  copy: src=drupal-check.phar dest=/home/vagrant mode=u+rwx
-  tags: drupal-check

--- a/conf/vagrant/provisioning/roles/drupal-check/tasks/mail.yml
+++ b/conf/vagrant/provisioning/roles/drupal-check/tasks/mail.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Drupal Check | Download drupal check
+  command: curl -O -L https://github.com/mglaman/drupal-check/releases/latest/download/drupal-check.phar
+  tags: drupal-check
+
+- name: Druupal Check | Copy Drupal Check
+  copy: src=drupal-check.phar dest=/home/vagrant mode=u+rwx
+  tags: drupal-check

--- a/conf/vagrant/provisioning/roles/drupal-check/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/drupal-check/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Drupal Check | Install drupal-check
+  get_url:
+    url: https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
+    dest: /home/vagrant/bin/drupal-check
+    mode: '0700'
+    timeout: 1800
+  tags: drupal-check
+
+# Note: phing and drupal-check have mutually exclusive requirements.
+# It'd be better to add drupal-check as a dependency of the drupal project
+# rather than as part of the virtual environment, but this will have to do for
+# now. Also note, drupal-check is added as part of the-build so it is available
+# to CircleCI.


### PR DESCRIPTION
To test: reprovision a Drupal project. From within the VM, see that `drupal-check` is now a command that is available to be run by the default vagrant user. It's nifty!