### PR TITLE
Switch nvm role for Ansible 2.9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/conf/vagrant/provisioning/roles/elnebuloso.nvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+
+* Switched the Ansible Galaxy role used to install nvm, since the previous role isn't compatible with Ansible 2.9
+
 ## 2.4.0 - October 18, 2019
 
 ### Added

--- a/conf/vagrant/provisioning/drupal8-skeleton.yml
+++ b/conf/vagrant/provisioning/drupal8-skeleton.yml
@@ -16,7 +16,7 @@
     - { role: drush }
     - { role: drupal-check }
     - { role: gulp }
-    - { role: leanbit.nvm,
+    - { role: elnebuloso.nvm,
         nvm_user: "vagrant",
         become: true,
       }

--- a/conf/vagrant/provisioning/requirements.yml
+++ b/conf/vagrant/provisioning/requirements.yml
@@ -1,4 +1,3 @@
 ---
 
-- src: leanbit.nvm
-  version: 0.0.4
+- src: elnebuloso.nvm


### PR DESCRIPTION
leanbit.nvm uses syntax that isn't compatible with Ansible 2.9, and hasn't been updated in 3 years so it's unlikely to be fixed.

I've replaced it with elnebuloso.nvm, which is a drop-in replacement (it uses the same variable names). This means that the Vagrantfile doesn't need to be changed for this fix. However, this role hasn't been updated in 2 years and contains syntax that will be deprecated in Ansible 2.11, so we're likely to face a similar issue in 6-12 months.