### PR TITLE
Keep composer updated on boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## UNRELEASED
+
+### Added
+
+* Added a trigger to the default Vagrantfile that keeps the installed version of Composer up to date (#68)
+
+### Updating to this version
+
+This version includes changes to the `Vagrantfile` template. To get these changes, either re-run the-vagrant's installer with `vendor/bin/the-vagrant-installer`, OR manually apply the changes from the [diff from #69](https://github.com/palantirnet/the-vagrant/pull/69/files).
+
 ## 2.5.0 - November 18, 2019
 
 ### Changed

--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -86,4 +86,11 @@ Vagrant.configure(2) do |config|
         }
     end
 
+    config.trigger.after [:up, :reload] do |trigger|
+        trigger.name = "Composer self-update"
+        trigger.run_remote = {
+            inline: "sudo -H composer self-update"
+        }
+    end
+
 end


### PR DESCRIPTION
Add a trigger to update the installed version of composer on vagrant up (#68).

This updates Composer itself, not the project dependencies, which should be generally good because Composer gets regular performance improvements and bug fixes.

In the infrequent cases where there's a breaking change in Composer (e.g. a schema change), it forces you to keep your project's `composer.json` up to date -- which is correct, because the general assumption is that any particular environment is running the latest composer.