### PR TITLE
The vagrant composer interaction changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Added
+
+* Added a trigger to the default Vagrantfile that keeps the installed version of Composer up to date (#68)
+
 ### Changed
 
 * Removed the custom drush wrapper in ~/bin. Drush 9 handles this itself.
@@ -9,7 +13,8 @@
 ### Updating from 2.5
 
 * This update does **not** require destroying your current vagrant box.
-* As a developer, you may want to:
+* This version includes changes to the `Vagrantfile` template. To get these changes, either re-run the-vagrant's installer with `vendor/bin/the-vagrant-installer`, OR manually apply the changes from the [diff from #69](https://github.com/palantirnet/the-vagrant/pull/69/files).
+* As a developer, you may also want to:
   1. From your Vagrant box, `rm ~/bin/drush`
   2. Log out of your vagrant and then back in before continuing to work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@
 ### Changed
 
 * Removed the custom drush wrapper in ~/bin. Drush 9 handles this itself.
+* Removed the `vagrant up` trigger that ran `composer install` on the project
 
 ### Updating from 2.5
 
 * This update does **not** require destroying your current vagrant box.
-* This version includes changes to the `Vagrantfile` template. To get these changes, either re-run the-vagrant's installer with `vendor/bin/the-vagrant-installer`, OR manually apply the changes from the [diff from #69](https://github.com/palantirnet/the-vagrant/pull/69/files).
+* This version includes changes to the `Vagrantfile` template. To get these changes, either re-run the-vagrant's installer with `vendor/bin/the-vagrant-installer`, OR manually apply the changes from the [diff from #70](https://github.com/palantirnet/the-vagrant/pull/70/files).
 * As a developer, you may also want to:
   1. From your Vagrant box, `rm ~/bin/drush`
   2. Log out of your vagrant and then back in before continuing to work

--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -86,4 +86,11 @@ Vagrant.configure(2) do |config|
         }
     end
 
+    config.trigger.after [:up, :reload] do |trigger|
+        trigger.name = "Composer self-update"
+        trigger.run_remote = {
+            inline: "sudo -H composer self-update"
+        }
+    end
+
 end

--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -79,13 +79,6 @@ Vagrant.configure(2) do |config|
         end
     end
 
-    config.trigger.before [:up, :reload] do |trigger|
-        trigger.name = "Composer Install"
-        trigger.run = {
-            inline: "composer install --ignore-platform-reqs"
-        }
-    end
-
     config.trigger.after [:up, :reload] do |trigger|
         trigger.name = "Composer self-update"
         trigger.run_remote = {


### PR DESCRIPTION
* Don't run `composer install` on the project (on the grounds that `vagrant up` should ONLY do things related to the VM)
* Do update composer itself on `vagrant up`, so that we're always using the latest version of Composer (#68)
