### PR TITLE
Remove user-specific provisioning and zsh configuration

### DIFF
--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -45,21 +45,21 @@
   command: /usr/bin/git config --global core.excludesfile ~/.gitignore
   tags: common
 
-- name: Ensure ~/bin exists
+- name: Common | Ensure ~/bin exists
   file:
     path: /home/vagrant/bin
     state: directory
     owner: vagrant
     mode: '755'
 
-- name: Add the ~/bin to the path
+- name: Common | Add the ~/bin to the path
   lineinfile: dest=/home/vagrant/.profile state=present line='export PATH="$PATH:$HOME/bin"'
-  tags: drush
+  tags: common
 
-- name: Add the project's vendor/bin to the path
+- name: Common | Add the project's vendor/bin to the path
   lineinfile: dest=/home/vagrant/.profile state=present line='export PATH="$PATH:/var/www/{{ hostname }}/vendor/bin"'
   tags: common
 
-- name: Change directory into the project root on login
+- name: Common | Change directory into the project root on login
   lineinfile: dest=/home/vagrant/.profile state=present line='cd /var/www/{{ hostname }}'
   tags: common

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -45,15 +45,6 @@
   command: /usr/bin/git config --global core.excludesfile ~/.gitignore
   tags: common
 
-- name: Check for user-specific provisioning script
-  stat: path=/var/www/{{ hostname }}/conf/provision-user
-  register: provision_user
-
-- name: Run user-specific provisioning.
-  command: /var/www/{{ hostname }}/conf/provision-user
-  when: provision_user.stat.exists
-  tags: common
-
 - name: Ensure ~/bin exists
   file:
     path: /home/vagrant/bin
@@ -67,14 +58,6 @@
 
 - name: Add the project's vendor/bin to the path
   lineinfile: dest=/home/vagrant/.profile state=present line='export PATH="$PATH:/var/www/{{ hostname }}/vendor/bin"'
-  tags: common
-
-- name: Add the ~/bin to the zsh path
-  lineinfile: dest=/home/vagrant/.zshrc state=present create=yes line='export PATH="$PATH:$HOME/bin"'
-  tags: drush
-
-- name: Add $HOME/bin and the project's vendor/bin to the zsh path
-  lineinfile: dest=/home/vagrant/.zshrc state=present create=yes line='export PATH="$PATH:$REPO/vendor/bin:$HOME/bin:/var/www/{{ hostname }}/vendor/bin"'
   tags: common
 
 - name: Change directory into the project root on login


### PR DESCRIPTION
The user-specific provisioning lines were causing problems on Mac OS 10.15 (Catalina):

> TASK [common : Check for user-specific provisioning script] ********************
> fatal: [projectname]: FAILED! => {"changed": false, "msg": "Permission denied"}

I took an informal poll about whether this, or zsh, was something that folks use, and it sounds like not at this time.