### PR TITLE
add upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ $> composer require palantirnet/the-vagrant
 
 You can re-run the install script later if you need to change your configuration.
 
+## Upgrading
+
+To upgrade the-vagrant in a project, you will need to:
+
+1. `composer update palantirnet/the-vagrant`
+2. Follow any steps from the [release notes](https://github.com/palantirnet/the-vagrant/releases).
+
+*Note:* If you need to update your VM, such as [drupalbox](https://app.vagrantup.com/palantir/boxes/drupalbox), you will need to run `vagrant destroy` then `vagrant box update` and `vagrant up`. Updating the VM doesn't always require updating The Vagrant.
+
 ## Customizing your environment
 
 Several things can be configured during the interactive installation:


### PR DESCRIPTION
This adds an "Upgrading" section to the readme to make it more clear when updates are required to The Vagrant, as well as how to update a VM to a new `drupalbox`. I know this supports other Vagrant boxes besides `palantirnet/drupalbox`, but this is the most common, so I used it as an example. I'm definitely open to rewording anything I added or moving it somewhere else altogether.