### PR TITLE
make install system packages compatible with ansible 2.9

### DIFF
--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Common | Install System Packages
   become: true
-  apt: pkg={{ item }} state=installed
+  apt: pkg={{ item }} state=present
   with_items: "{{ system_packages }}"
   tags: common
 


### PR DESCRIPTION
This is related to #65 and is required when projects use the `ansible_system_packages` property.

To test:
- change the line in your `composer.json` to:
    - `"palantirnet/the-vagrant": "dev-system-packages-ansible"`
- `composer update palantirnet/the-vagrant`
- add the property to your Vagrantfile; for example:
    - `ansible_system_packages = ["python-mysqldb"]`
- `vagrant provision`
- Verify the package(s) are installed successfully.