### PR TITLE
Add provisioning steps for older boxes

### DIFF
--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # These steps ("Update Yarn apt key" and "Remove Duplicity PPA repo") were added to fix issues with
-# updating the apt cache on older boxes. Once the older versions (1.3.0 and below) are no longer supported,
+# updating the apt cache on older boxes. Once the older versions (1.4.0 and below) are no longer supported,
 # these first two steps can be removed.
 
 - name: Common | Update Yarn apt key

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+# These steps ("Update Yarn apt key" and "Remove Duplicity PPA repo") were added to fix issues with
+# updating the apt cache on older boxes. Once the older versions (1.3.0 and below) are no longer supported,
+# these first two steps can be removed.
+
 - name: Common | Update Yarn apt key
   become: true
   command: apt-key adv --keyserver keys.gnupg.net --recv-keys 72ECF46A56B4AD39C907BBB71646B01B86E50310

--- a/conf/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/conf/vagrant/provisioning/roles/common/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Common | Update Yarn apt key
+  become: true
+  command: apt-key adv --keyserver keys.gnupg.net --recv-keys 72ECF46A56B4AD39C907BBB71646B01B86E50310
+
+- name: Common | Remove Duplicity PPA repo
+  become: true
+  apt_repository:
+    repo: ppa:duplicity-team
+    state: absent
+  tags: common
+
 - name: Common | Update apt cache
   become: true
   apt: update-cache=yes


### PR DESCRIPTION
- Adds a step to update the expired Yarn apt key.
- Adds a step to remove the "duplicity-team" PPA repository that no longer exists.

## Testing

- Set the version constraints for a project to use `< 1.4.0`
- `vagrant destroy`
- `vagrant up`
- Verify provisioning completes (especially the "Update apt cache" step)
- Set the version constraints to allow `1.4.0` and above.
- `vagrant destroy`
- `vagrant up`
- Verify provisioning completes as above.

Note: This was tested with box versions `1.3.0` and `1.4.1`.