### PR TITLE
Remove the option during install to copy and customize all roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## UNRELEASED
+
+### Changed
+
+* Removed the install wizard option to copy the Ansible roles into your project and customize. This can still be done, but in almost all cases adding a custom playbook is more maintainable. Existing setups that use this approach will continue to work. ([PR #76](https://github.com/palantirnet/the-vagrant/pull/76))
+
 ## 2.6.2 - May 12, 2020
 
 ### Fixed

--- a/tasks/vagrant.xml
+++ b/tasks/vagrant.xml
@@ -10,7 +10,6 @@
     <property name="default.enable_solr" value="Y" />
     <property name="default.enable_https" value="Y" />
     <property name="default.node_version" value="8" />
-    <property name="default.copy_roles" value="n" />
     <property name="default.custom_playbook" value="n" />
 
 
@@ -22,17 +21,7 @@
         <input propertyName="enable_solr" message="Enable Solr " promptChar="?" validArgs="Y,n" defaultValue="${default.enable_solr}" />
         <input propertyName="enable_https" message="Enable HTTPS " promptChar="?" validArgs="Y,n" defaultValue="${default.enable_https}" />
         <propertyprompt propertyName="node_version" defaultValue="${default.node_version}" promptText="Node version" promptCharacter=":" useExistingValue="true"/>
-        <input propertyName="copy_roles" message="Copy Ansible roles into your project for customization " promptChar="?" validArgs="Y,n" defaultValue="${default.copy_roles}" />
-
-        <if>
-            <equals arg1="${copy_roles}" arg2="n"/>
-            <then>
-                <input propertyName="custom_playbook" message="OR add an additional Ansible playbook to your project  " promptChar="?" validArgs="Y,n" defaultValue="${default.custom_playbook}" />
-            </then>
-            <else>
-                <property name="custom_playbook" value="${default.custom_playbook}" />
-            </else>
-        </if>
+        <input propertyName="custom_playbook" message="Add a custom Ansible playbook to your project  " promptChar="?" validArgs="Y,n" defaultValue="${default.custom_playbook}" />
 
         <!-- Source locations -->
         <property name="vagrant.installdir" value="${application.startdir}"/>
@@ -42,22 +31,6 @@
         <property name="vagrant.vagrantfile.dest" value="${vagrant.installdir}/Vagrantfile"/>
 
         <!-- Install based on interactive prompt responses above -->
-        <if>
-            <equals arg1="${copy_roles}" arg2="Y"/>
-            <then>
-                <!-- Provision from copies of the playbooks from the-vagrant -->
-                <property name="vagrant.ansible.playbook" value="provisioning/${projectname}.yml"/>
-                <copy todir="${vagrant.installdir}/provisioning">
-                    <fileset dir="${vagrant.ansible.source}"/>
-                </copy>
-                <move file="${vagrant.installdir}/provisioning/drupal8-skeleton.yml" tofile="${vagrant.installdir}/provisioning/${projectname}.yml"/>
-            </then>
-            <else>
-                <!-- Provision directly from the-vagrant playbooks -->
-                <property name="vagrant.ansible.playbook" value="vendor/palantirnet/the-vagrant/conf/vagrant/provisioning/drupal8-skeleton.yml"/>
-            </else>
-        </if>
-
         <if>
             <equals arg1="${custom_playbook}" arg2="Y"/>
             <then>
@@ -105,7 +78,7 @@
             <filterchain>
                 <replacetokens>
                     <token key="projectname" value="${projectname}"/>
-                    <token key="playbook" value="${vagrant.ansible.playbook}"/>
+                    <token key="playbook" value="vendor/palantirnet/the-vagrant/conf/vagrant/provisioning/drupal8-skeleton.yml"/>
                     <token key="ansible_solr_enabled" value="${ansible_solr_enabled}"/>
                     <token key="ansible_https_enabled" value="${ansible_https_enabled}"/>
                     <token key="ansible_node_version" value="${node_version}"/>


### PR DESCRIPTION
Only give the option to add an additional playbook. This won't break existing projects, since the variable that allows changing the provisioning source is still there.