### PR TITLE
Default to installing Node.js 12 and nvm v0.35.3

### DIFF
--- a/conf/vagrant/Vagrantfile
+++ b/conf/vagrant/Vagrantfile
@@ -64,7 +64,7 @@ Vagrant.configure(2) do |config|
             "project_web_root" => ansible_project_web_root,
             "timezone" => ansible_timezone,
             "system_packages" => ansible_system_packages,
-            "nvm_version" => "v0.33.11",
+            "nvm_version" => "v0.35.3",
             "nvm_default_node_version" => ansible_node_version,
             "nvm_node_versions" => [ ansible_node_version ],
         }

--- a/tasks/vagrant.xml
+++ b/tasks/vagrant.xml
@@ -9,7 +9,7 @@
     <property name="default.project_web_root" value="web" />
     <property name="default.enable_solr" value="Y" />
     <property name="default.enable_https" value="Y" />
-    <property name="default.node_version" value="8" />
+    <property name="default.node_version" value="12" />
     <property name="default.custom_playbook" value="n" />
 
 


### PR DESCRIPTION
Testing instructions:
1. In a project, require this dev branch
2. Run the installer `vendor/bin/the-vagrant-installer`
3. It should default to Node 12
4. Bring up the box `vagrant up`
5. Log in `vagrant ssh`
6. Run `nvm list`; a 12.* version of Node.js should be installed
7. Run `nvm --version`; version 0.35.3 should be installed